### PR TITLE
Fix on track not triggered, with explanation of possible why

### DIFF
--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -70,6 +70,22 @@ export const Room = ({
             console.log("received offer");
             setLobby(false);
             const pc = new RTCPeerConnection();
+            pc.ontrack = (e) => {
+                alert('ontrack');
+                console.error('inside ontrack');
+                const { track, type } = e;
+                if (type == 'audio') {
+                // setRemoteAudioTrack(track);
+                // @ts-ignore
+                remoteVideoRef.current.srcObject.addTrack(track);
+                } else {
+                // setRemoteVideoTrack(track);
+                // @ts-ignore
+                remoteVideoRef.current.srcObject.addTrack(track);
+                }
+                //@ts-ignore
+                remoteVideoRef.current.play();
+            };
             pc.setRemoteDescription(remoteSdp)
             const sdp = await pc.createAnswer();
             //@ts-ignore
@@ -83,22 +99,7 @@ export const Room = ({
             // trickle ice 
             setReceivingPc(pc);
             window.pcr = pc;
-            pc.ontrack = (e) => {
-                alert("ontrack");
-                // console.error("inside ontrack");
-                // const {track, type} = e;
-                // if (type == 'audio') {
-                //     // setRemoteAudioTrack(track);
-                //     // @ts-ignore
-                //     remoteVideoRef.current.srcObject.addTrack(track)
-                // } else {
-                //     // setRemoteVideoTrack(track);
-                //     // @ts-ignore
-                //     remoteVideoRef.current.srcObject.addTrack(track)
-                // }
-                // //@ts-ignore
-                // remoteVideoRef.current.play();
-            }
+
 
             pc.onicecandidate = async (e) => {
                 if (!e.candidate) {


### PR DESCRIPTION
Setting the ontrack after `const pc = new RTCPeerConnection();` fix the issue, Reason:

look at 

https://stackoverflow.com/questions/61921201/webrtc-ontrack-event-handler-not-firing-in-async-function

> ontrack fires as part of setRemoteDescription. However, in your async code you are only adding a ontrack handler later so it won't get triggered.
> 
Also diggin more into this 

> When two peers are establishing a connection, they exchange SDP (Session Description Protocol) information, which includes details about media tracks (audio, video, etc.). As soon as the remote description is set with setRemoteDescription on a peer connection, WebRTC begins the process of establishing a connection and setting up media tracks.
> 
> If the ontrack event handler is not set up before setRemoteDescription, there's a risk that you might miss the event where these media tracks are added to the connection. This is especially true in fast networks or when both peers are on the same local network, where the connection setup can happen almost instantaneously.

That's why it wasn't triggering 