### PR TITLE
fix ontrack event not firing 

### DIFF
--- a/frontend/src/components/Room.tsx
+++ b/frontend/src/components/Room.tsx
@@ -69,12 +69,22 @@ export const Room = ({
         socket.on("offer", async ({roomId, sdp: remoteSdp}) => {
             console.log("received offer");
             setLobby(false);
+            const stream = new MediaStream();
             const pc = new RTCPeerConnection();
+
+            pc.ontrack = (e) => {
+                console.log("inside ontrack");
+
+                stream.addTrack(e.track)
+                if(remoteVideoRef.current) {
+                    remoteVideoRef.current.srcObject = stream
+                }
+            }
+
             pc.setRemoteDescription(remoteSdp)
             const sdp = await pc.createAnswer();
             //@ts-ignore
             pc.setLocalDescription(sdp)
-            const stream = new MediaStream();
             if (remoteVideoRef.current) {
                 remoteVideoRef.current.srcObject = stream;
             }
@@ -82,23 +92,7 @@ export const Room = ({
             setRemoteMediaStream(stream);
             // trickle ice 
             setReceivingPc(pc);
-            window.pcr = pc;
-            pc.ontrack = (e) => {
-                alert("ontrack");
-                // console.error("inside ontrack");
-                // const {track, type} = e;
-                // if (type == 'audio') {
-                //     // setRemoteAudioTrack(track);
-                //     // @ts-ignore
-                //     remoteVideoRef.current.srcObject.addTrack(track)
-                // } else {
-                //     // setRemoteVideoTrack(track);
-                //     // @ts-ignore
-                //     remoteVideoRef.current.srcObject.addTrack(track)
-                // }
-                // //@ts-ignore
-                // remoteVideoRef.current.play();
-            }
+           
 
             pc.onicecandidate = async (e) => {
                 if (!e.candidate) {
@@ -118,34 +112,35 @@ export const Room = ({
                 roomId,
                 sdp: sdp
             });
-            setTimeout(() => {
-                const track1 = pc.getTransceivers()[0].receiver.track
-                const track2 = pc.getTransceivers()[1].receiver.track
-                console.log(track1);
-                if (track1.kind === "video") {
-                    setRemoteAudioTrack(track2)
-                    setRemoteVideoTrack(track1)
-                } else {
-                    setRemoteAudioTrack(track1)
-                    setRemoteVideoTrack(track2)
-                }
-                //@ts-ignore
-                remoteVideoRef.current.srcObject.addTrack(track1)
-                //@ts-ignore
-                remoteVideoRef.current.srcObject.addTrack(track2)
-                //@ts-ignore
-                remoteVideoRef.current.play();
-                // if (type == 'audio') {
-                //     // setRemoteAudioTrack(track);
-                //     // @ts-ignore
-                //     remoteVideoRef.current.srcObject.addTrack(track)
-                // } else {
-                //     // setRemoteVideoTrack(track);
-                //     // @ts-ignore
-                //     remoteVideoRef.current.srcObject.addTrack(track)
-                // }
-                // //@ts-ignore
-            }, 5000)
+
+            // setTimeout(() => {
+            //     const track1 = pc.getTransceivers()[0].receiver.track
+            //     const track2 = pc.getTransceivers()[1].receiver.track
+            //     console.log(track1);
+            //     if (track1.kind === "video") {
+            //         setRemoteAudioTrack(track2)
+            //         setRemoteVideoTrack(track1)
+            //     } else {
+            //         setRemoteAudioTrack(track1)
+            //         setRemoteVideoTrack(track2)
+            //     }
+            //     //@ts-ignore
+            //     remoteVideoRef.current.srcObject.addTrack(track1)
+            //     //@ts-ignore
+            //     remoteVideoRef.current.srcObject.addTrack(track2)
+            //     //@ts-ignore
+            //     remoteVideoRef.current.play();
+            //     // if (type == 'audio') {
+            //     //     // setRemoteAudioTrack(track);
+            //     //     // @ts-ignore
+            //     //     remoteVideoRef.current.srcObject.addTrack(track)
+            //     // } else {
+            //     //     // setRemoteVideoTrack(track);
+            //     //     // @ts-ignore
+            //     //     remoteVideoRef.current.srcObject.addTrack(track)
+            //     // }
+            //     // //@ts-ignore
+            // }, 5000)
         });
 
         socket.on("answer", ({roomId, sdp: remoteSdp}) => {
@@ -166,21 +161,21 @@ export const Room = ({
             console.log({candidate, type})
             if (type == "sender") {
                 setReceivingPc(pc => {
-                    if (!pc) {
-                        console.error("receicng pc nout found")
-                    } else {
-                        console.error(pc.ontrack)
-                    }
+                    // if (!pc) {
+                    //     console.error("receicng pc nout found")
+                    // } else {
+                    //     console.error(pc.ontrack)
+                    // }
                     pc?.addIceCandidate(candidate)
                     return pc;
                 });
             } else {
                 setSendingPc(pc => {
-                    if (!pc) {
-                        console.error("sending pc nout found")
-                    } else {
-                        // console.error(pc.ontrack)
-                    }
+                    // if (!pc) {
+                    //     console.error("sending pc nout found")
+                    // } else {
+                    //     // console.error(pc.ontrack)
+                    // }
                     pc?.addIceCandidate(candidate)
                     return pc;
                 });
@@ -201,7 +196,7 @@ export const Room = ({
 
     return <div>
         Hi {name}
-        <video autoPlay width={400} height={400} ref={localVideoRef} />
+        <video autoPlay width={400} height={400} ref={localVideoRef} style={{marginRight: "16px"}} />
         {lobby ? "Waiting to connect you to someone" : null}
         <video autoPlay width={400} height={400} ref={remoteVideoRef} />
     </div>


### PR DESCRIPTION
Turns out, you were setting up the event handler a bit too late, after setting the remote description.

So, I moved the ontrack setup right after we create the RTCPeerConnection. Now it’s ready to go as soon as a track is added. Found a similar issue on StackOverflow that helped me out [here](https://stackoverflow.com/questions/41145823/rtcpeerconnection-ontrack-event-not-firing) 

Now, the ontrack event is firing just fine (check the console logs) and the video is showing up on the room page (see attached screenshots).

![Screenshot 2024-01-10 at 18-21-06 Vite React TS](https://github.com/hkirat/omegle/assets/79351619/0356a434-e5fb-4220-b952-6e0c2ff6d385)
![Screenshot 2024-01-10 182130](https://github.com/hkirat/omegle/assets/79351619/ad200580-6938-447f-931a-a4f754b393ab)
